### PR TITLE
Preserve item data in Auction House listings

### DIFF
--- a/src/main/java/com/sumutiu/easyeconomy/commands/AHCommand.java
+++ b/src/main/java/com/sumutiu/easyeconomy/commands/AHCommand.java
@@ -63,13 +63,15 @@ public class AHCommand {
         // Item info BEFORE modifying stack
         String itemName = held.getHoverName().getString();
         String itemId = BuiltInRegistries.ITEM.getKey(held.getItem()).toString();
+        String itemNbt = held.save(player.registryAccess()).toString();
 
         AHStorage.AHListing listing = new AHStorage.AHListing(
                 itemId,
                 qty,
                 price,
                 player.getUUID(),
-                player.getName().getString()
+                player.getName().getString(),
+                itemNbt
         );
 
         var listings = AHStorage.loadListings(player.getUUID());

--- a/src/main/java/com/sumutiu/easyeconomy/storage/AHStorage.java
+++ b/src/main/java/com/sumutiu/easyeconomy/storage/AHStorage.java
@@ -20,14 +20,16 @@ public class AHStorage {
         public long timestamp; // epoch millis
         public UUID seller;
         public String sellerName;
+        public String nbt; // Serialized ItemStack SNBT
 
-        public AHListing(String itemId, int quantity, long price, UUID seller, String sellerName) {
+        public AHListing(String itemId, int quantity, long price, UUID seller, String sellerName, String nbt) {
             this.itemId = itemId;
             this.quantity = quantity;
             this.price = price;
             this.timestamp = System.currentTimeMillis();
             this.seller = seller;
             this.sellerName = sellerName;
+            this.nbt = nbt;
         }
     }
 

--- a/src/main/java/com/sumutiu/easyeconomy/storage/AHStorageHelper.java
+++ b/src/main/java/com/sumutiu/easyeconomy/storage/AHStorageHelper.java
@@ -1,6 +1,9 @@
 package com.sumutiu.easyeconomy.storage;
 
 import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.TagParser;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -21,32 +24,48 @@ public class AHStorageHelper {
      * Converts an AHListing into a proper ItemStack.
      * Returns ItemStack.EMPTY if anything is invalid.
      */
-    public static ItemStack fromListing(AHStorage.AHListing listing) {
+    public static ItemStack fromListing(AHStorage.AHListing listing, HolderLookup.Provider registries) {
         try {
-            if (listing == null || listing.itemId == null) return ItemStack.EMPTY;
+            if (listing == null) return ItemStack.EMPTY;
 
-            Identifier id = Identifier.tryParse(listing.itemId);
-            if (id == null) {
-                Logger(1, String.format(AH_INVALID_ID, listing.itemId));
-                return ItemStack.EMPTY;
+            ItemStack stack = ItemStack.EMPTY;
+
+            // Try loading from NBT first to preserve components/enchantments
+            if (listing.nbt != null && !listing.nbt.isEmpty() && registries != null) {
+                try {
+                    CompoundTag tag = TagParser.parseTag(listing.nbt);
+                    stack = ItemStack.parse(registries, tag).orElse(ItemStack.EMPTY);
+                    // Ensure the quantity is what the listing says, not what was in the NBT
+                    if (!stack.isEmpty()) {
+                        stack.setCount(Math.max(1, listing.quantity));
+                    }
+                } catch (Exception e) {
+                    Logger(1, "Failed to parse item NBT: " + e.getMessage());
+                }
             }
 
-            Optional<Holder.Reference<Item>> holder = BuiltInRegistries.ITEM.get(id);
+            // Fallback for older listings or if NBT loading failed
+            if (stack.isEmpty()) {
+                if (listing.itemId == null) return ItemStack.EMPTY;
 
-            if (holder.isEmpty()) {
-                Logger(1, String.format(AH_ID_NOT_FOUND, listing.itemId));
-                return ItemStack.EMPTY;
+                Identifier id = Identifier.tryParse(listing.itemId);
+                if (id == null) {
+                    Logger(1, String.format(AH_INVALID_ID, listing.itemId));
+                    return ItemStack.EMPTY;
+                }
+
+                Item item = BuiltInRegistries.ITEM.get(id).orElseThrow().value();
+
+                if (item == Items.AIR) {
+                    Logger(1, String.format(AH_ID_NOT_FOUND, listing.itemId));
+                    return ItemStack.EMPTY;
+                }
+
+                int qty = Math.max(1, listing.quantity);
+                stack = new ItemStack(item, qty);
             }
 
-            Item item = holder.get().value();
-
-            if (item == Items.AIR) {
-                Logger(1, String.format(AH_ID_NOT_FOUND, listing.itemId));
-                return ItemStack.EMPTY;
-            }
-
-            int qty = Math.max(1, listing.quantity);
-            return new ItemStack(item, qty);
+            return stack;
 
         } catch (Exception e) {
             Logger(2, String.format(AH_ID_ITEMSTACK_ERROR, e.getMessage()));

--- a/src/main/java/com/sumutiu/easyeconomy/util/AHExpiredScreenHandler.java
+++ b/src/main/java/com/sumutiu/easyeconomy/util/AHExpiredScreenHandler.java
@@ -30,12 +30,14 @@ public class AHExpiredScreenHandler extends AbstractContainerMenu {
 
     private final Container inventory;
     private final List<AHStorage.AHListing> expiredListings;
+    private final Player player;
     private int currentPage = 0;
 
     public AHExpiredScreenHandler(int syncId, Container inventory, List<AHStorage.AHListing> expiredListings, Player player) {
         super(MenuType.GENERIC_9x6, syncId);
         this.inventory = inventory;
         this.expiredListings = expiredListings;
+        this.player = player;
 
         // Auction house slots with click handling
         for (int i = 0; i < SIZE; i++) {
@@ -82,7 +84,7 @@ public class AHExpiredScreenHandler extends AbstractContainerMenu {
         int listingIndex = currentPage * ITEMS_PER_PAGE + slotIndex;
         if (slotIndex >= 0 && slotIndex < ITEMS_PER_PAGE && listingIndex < expiredListings.size()) {
             AHStorage.AHListing listing = expiredListings.get(listingIndex);
-            ItemStack stack = AHStorageHelper.fromListing(listing);
+            ItemStack stack = AHStorageHelper.fromListing(listing, serverPlayer.registryAccess());
 
             if (stack == null || stack.isEmpty()) {
                 PrivateMessage(serverPlayer, AH_BUY_ERROR);
@@ -125,7 +127,7 @@ public class AHExpiredScreenHandler extends AbstractContainerMenu {
 
             if (listingIndex < expiredListings.size()) {
                 AHStorage.AHListing listing = expiredListings.get(listingIndex);
-                ItemStack stack = AHStorageHelper.fromListing(listing);
+                ItemStack stack = AHStorageHelper.fromListing(listing, player.registryAccess());
                 if (stack == null) stack = ItemStack.EMPTY;
 
                 String sellerName = listing.sellerName != null ? listing.sellerName : "Unknown";

--- a/src/main/java/com/sumutiu/easyeconomy/util/AHScreenHandler.java
+++ b/src/main/java/com/sumutiu/easyeconomy/util/AHScreenHandler.java
@@ -31,6 +31,7 @@ public class AHScreenHandler extends AbstractContainerMenu {
 
     private final Container inventory;
     private final List<AHStorage.AHListing> listings;
+    private final Player player;
 
     private boolean inConfirmation = false;
     private int confirmSlot = -1;
@@ -40,6 +41,7 @@ public class AHScreenHandler extends AbstractContainerMenu {
         super(MenuType.GENERIC_9x6, syncId);
         this.inventory = inventory;
         this.listings = listings;
+        this.player = player;
 
         // ---------------- Auction House Slots ----------------
         for (int i = 0; i < SIZE; i++) {
@@ -124,7 +126,7 @@ public class AHScreenHandler extends AbstractContainerMenu {
         inConfirmation = false;
 
         AHStorage.AHListing listing = listings.get(confirmSlot);
-        ItemStack purchased = AHStorageHelper.fromListing(listing);
+        ItemStack purchased = AHStorageHelper.fromListing(listing, serverPlayer.registryAccess());
 
         if (purchased == null || purchased.isEmpty()) {
             PrivateMessage(serverPlayer, AH_BUY_ERROR);
@@ -210,7 +212,7 @@ public class AHScreenHandler extends AbstractContainerMenu {
             if (listingIndex >= listings.size()) continue;
 
             AHStorage.AHListing listing = listings.get(listingIndex);
-            ItemStack stack = AHStorageHelper.fromListing(listing);
+            ItemStack stack = AHStorageHelper.fromListing(listing, player.registryAccess());
             if (stack == null) stack = ItemStack.EMPTY;
 
             String sellerName = listing.sellerName != null ? listing.sellerName : "Unknown";
@@ -274,7 +276,7 @@ public class AHScreenHandler extends AbstractContainerMenu {
         }
 
         AHStorage.AHListing listing = listings.get(confirmSlot);
-        inventory.setItem(22, AHStorageHelper.fromListing(listing));
+        inventory.setItem(22, AHStorageHelper.fromListing(listing, player.registryAccess()));
 
         broadcastChanges();
     }


### PR DESCRIPTION
When listing enchanted items or items with custom names in the auction house, they would lose all their enchantments and custom names upon being purchased or claimed. This was because the mod only saved the item's ID and quantity.

I have updated the Auction House storage system to serialize the full `ItemStack` to a String (SNBT) using Minecraft's built-in serialization. This ensures all item components, including enchantments, custom names, lore, and other data, are preserved. I also added a check to ensure the listing's quantity is correctly applied to the reconstructed item to prevent any duplication bugs. Additionally, I updated the Auction House GUI to correctly pass the necessary registry information for parsing the items.

---
*PR created automatically by Jules for task [282072471287594502](https://jules.google.com/task/282072471287594502) started by @Sumutiu*